### PR TITLE
Add Airdash

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@
 - [FlutterWeather](https://github.com/ArizArmeidi/FlutterWeather) - Weather App with clean and modern UI by [Ariz Armeidi](https://github.com/ArizArmeidi).
 - [One Second Diary](https://github.com/KyleKun/one_second_diary) - Minimalist Video Diary app by [KyleKun](https://github.com/KyleKun).
 - [Blink Comparison](https://github.com/proninyaroslav/blink-comparison) - Simplifies comparing photos of tamper-evident seals and patterns using your eyes by [Yaroslav Pronin](https://github.com/proninyaroslav)
+- [Airdash](https://github.com/simonbengtsson/airdash) - Share files to any device by [Simon Bengtsson](https://github.com/simonbengtsson)
 
 ### Travel
 


### PR DESCRIPTION
Suggest adding the recently open sourced Airdash file transfer app.

- Link to repository: https://github.com/simonbengtsson/airdash
- Link to app website (with Windows, Android, iOS and macOS store links): https://airdash-project.web.app

**Checklist**

- [x] I read [How to contribute](https://github.com/tortuvshin/open-source-flutter-apps/blob/master/CONTRIBUTING.md)
- [x] Added a link to the repo in the PR
