### PR TITLE
Add Art and Design category; add ColorHap app

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 
 ## Contents
 
+- [Art and Design](#art-and-design)
 - [Business](#business)
 - [Communication](#communication)
 - [Education](#education)
@@ -34,6 +35,10 @@
 - [Tools](#tools)
 - [Travel](#travel)
 - [Simulation](#simulation)
+
+### Art and Design
+
+- [ColorHap](https://github.com/tecdrop/color_hap) - A random color generator that shuffles millions of colors and lets you copy and share colors with others by [Tecdrop](https://www.tecdrop.com/).
 
 ### Business
 


### PR DESCRIPTION
## Description

I suggest adding a new category `Art and Design`, which is also an app category on Google Play for _Sketchbooks, painter tools, art and design tools, coloring books_.

I also suggest adding the following open-source Flutter app:

- [ColorHap](https://github.com/tecdrop/color_hap) - A random color generator that shuffles millions of colors and lets you copy and share colors with others by [Tecdrop](https://www.tecdrop.com/).

to this new category.

**Checklist**

- [x] I read [How to contribute](https://github.com/tortuvshin/open-source-flutter-apps/blob/master/CONTRIBUTING.md)
- [x] Added a link to the repo in the PR
