### PR TITLE
Add BeeCount to Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@
 - [HADWIN](https://github.com/brownboycodes/HADWIN) - a prototype of a fund transfer platform by [Nabhodipta Garai](https://github.com/brownboycodes).
 - [MMAS: Money Tracker](https://github.com/floranguyen0/mmas-money-tracker) - An optimized application for daily expense tracking and finance management by [Flora](https://github.com/floranguyen0).
 - [Budgeto](https://github.com/tejasbadone/budgeto) - finance management prototype app with categories such as needs, expenses, and savings and features like autopay, investments, and planning tools by [Tejas Badone](https://github.com/tejasbadone).
+- [BeeCount](https://github.com/TNT-Likely/BeeCount) - Privacy-first cross-platform expense tracker with self-hostable cloud sync (BeeCount Cloud, iCloud, Supabase, WebDAV, S3) and offline-first design by [TNT-Likely](https://github.com/TNT-Likely).
 
 ### Health and Fitness
 


### PR DESCRIPTION
## Summary

Adds **BeeCount** to the Finance section.

BeeCount is a privacy-first cross-platform personal expense tracker (Android, iOS, Web), offline-first, with multi-cloud sync — self-hostable BeeCount Cloud, iCloud, Supabase, WebDAV, or S3. ~1.5k★, 200+ forks, active development.

- Source: https://github.com/TNT-Likely/BeeCount
- App Store: https://apps.apple.com/app/id6754611670
- Google Play: https://play.google.com/store/apps/details?id=com.tntlikely.beecount

## Compliance with CONTRIBUTING.md

- [x] Searched previous suggestions for duplicates
- [x] Individual PR for this single suggestion
- [x] Format: `[Name](repo) - description by [Author](profile).`
- [x] Description doesn't mention Flutter (implied) or iOS/Android/Swift/Java
- [x] Description ends with a period
- [x] Entry positioned as the last item in the Finance category
- [x] Project meets eligibility (active, English README, English code comments, sufficient stars, working app on both stores)

## Affiliation disclosure

I'm the author of BeeCount (@TNT-Likely).

## License note (transparency)

BeeCount uses a custom commercial source-available license (free for personal/non-commercial use; commercial use requires a paid license). It's not OSI-approved. If that excludes it from this list, no problem — happy to close the PR. Most of this list's existing entries are MIT/Apache, so I want to flag this upfront.