### PR TITLE
Update Tura product description

### DIFF
--- a/data/records/tura.yml
+++ b/data/records/tura.yml
@@ -1,8 +1,7 @@
 kind: project
 name: Tura
 slug: tura
-description: A local open-source AI coding agent with CLI, TUI, web, and desktop interfaces for
-  structured tool execution and context-aware development workflows.
+description: Build agent that uses 80% less token and delivers better results.
 category: tools
 tags:
   - coding-agent


### PR DESCRIPTION
## What this PR does

Updates the human-owned Tura description to the project's current product wording.

## Why

Keeps the directory entry aligned with the canonical GitHub project description.

## How to verify

Open data/records/tura.yml and confirm only the top-level description field changed; generated GitHub metadata remains untouched.

## Checklist

- [ ] pnpm exec grove validate passes
- [ ] pnpm run build succeeds locally
- [x] The slug remains unique and matches data/records/tura.yml